### PR TITLE
Support [iframe] markup for embedding Iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ The following elements are supported:
   [CMSimple\_XH](https://cmsimple-xh.org/)
 - `[img]https://cmsimple-xh.org/userfiles/images/flags/en.gif[/img]`:
   ![](https://cmsimple-xh.org/userfiles/images/flags/en.gif)
+- `[iframe]https://cmsimple-xh.org/userfiles/images/flags/en.gif[/iframe]`:
+  ![](https://cmsimple-xh.org/userfiles/images/flags/en.gif)  
+  *Iframes are used to embed external content, for instance, Youtube videos.*
 - `[size=150]large text[/size]`:
   <span style="font-size:150%">large text</span>
 - `[list][*]One [*]Two[/list]`:

--- a/README_DE.md
+++ b/README_DE.md
@@ -115,6 +115,9 @@ BBCode verfügbar. Die folgenden Elemente werden unterstützt:
   [CMSimple\_XH](https://cmsimple-xh.org/)
 - `[img]https://cmsimple-xh.org/userfiles/images/flags/de.gif[/img]`:
   ![](https://cmsimple-xh.org/userfiles/images/flags/de.gif)
+- `[iframe]https://cmsimple-xh.org/userfiles/images/flags/de.gif[/iframe]`:
+  ![](https://cmsimple-xh.org/userfiles/images/flags/de.gif)  
+  *Iframes werden verwendet, um externe Inhalte einzubinden, z.B. Youtube-Videos.*
 - `[size=150]große Schrift[/size]`:
   <span style="font-size:150%">große Schrift</span>
 - `[list][*]Eins [*]Zwei[/list]`:

--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,9 @@
 <project name="Forum" default="help">
 
     <target name="help" description="lists available targets">
-        <exec command="phing -l" outputProperty="help"/>
+        <exec executable="phing" outputProperty="help">
+            <arg value="-l"/>
+        </exec>
         <echo>${help}</echo>
     </target>
 
@@ -33,7 +35,9 @@
 
     <target name="compat"
             description="checks compatibility with PHP_CompatInfo">
-        <exec command="phpcompatinfo analyser:run --alias current" logoutput="true"/>
+        <exec executable="phpcompatinfo" logoutput="true">
+            <arg line="analyser:run --alias current"/>
+        </exec>
     </target>
 
     <target name="gen-help" description="builds help.htm from README.md">
@@ -77,7 +81,9 @@
     </target>
 
     <target name="coverage" description="generates coverage report">
-        <exec command="phpunit --configuration coverage.xml" logoutput="true"/>
+        <exec executable="phpunit" logoutput="true">
+            <arg line="--configuration coverage.xml"/>
+        </exec>
     </target>
 
     <target name="minify" description="minifies JS files">
@@ -96,7 +102,9 @@
     </target>
 
     <target name="build" description="builds a distributable ZIP archive">
-        <exec command="git archive -o export.zip HEAD" checkreturn="true"/>
+        <exec executable="git" checkreturn="true">
+            <arg line="archive -o export.zip HEAD"/>
+        </exec>
         <unzip file="export.zip" todir="export"/>
         <delete file="export.zip"/>
         <phingcall target="minify">

--- a/classes/BBCode.php
+++ b/classes/BBCode.php
@@ -38,15 +38,19 @@ class BBCode
      */
     private $emoticonDir;
 
+    /** @var string */
+    private $iframeTitle;
+
     /**
      * @param string $emoticonDir
      */
-    public function __construct($emoticonDir)
+    public function __construct($emoticonDir, $iframeTitle)
     {
         $this->pattern = '/\[(i|b|u|s|url|img|iframe|size|list|quote|code)(=.*?)?]'
             . '(.*?)\[\/\1]/su';
         $this->context = array();
         $this->emoticonDir = rtrim($emoticonDir, '/') . '/';
+        $this->iframeTitle = $iframeTitle;
     }
 
     /**
@@ -152,7 +156,11 @@ class BBCode
         if (!preg_match('/^http(s)?:/', $url)) {
             return $matches[0];
         }
-        return '<div class="iframe_container"><iframe src="' . $url . '" title="' . basename($url) . '"></iframe></div>';
+        return sprintf(
+            '<div class="iframe_container"><iframe src="%s" title="%s"></iframe></div>',
+            $url,
+            $this->iframeTitle
+        );
     }
 
     /**

--- a/classes/BBCode.php
+++ b/classes/BBCode.php
@@ -43,7 +43,7 @@ class BBCode
      */
     public function __construct($emoticonDir)
     {
-        $this->pattern = '/\[(i|b|u|s|url|img|size|list|quote|code)(=.*?)?]'
+        $this->pattern = '/\[(i|b|u|s|url|img|size|list|quote|code|iframe)(=.*?)?]'
             . '(.*?)\[\/\1]/su';
         $this->context = array();
         $this->emoticonDir = rtrim($emoticonDir, '/') . '/';
@@ -70,7 +70,7 @@ class BBCode
      */
     private function doConvert($matches)
     {
-        $inlines = array('i', 'b', 'u', 's', 'url', 'img', 'size');
+        $inlines = array('i', 'b', 'u', 's', 'url', 'iframe', 'img', 'size');
         array_push(
             $this->context,
             in_array($matches[1], $inlines) ? 'inline' : $matches[1]
@@ -83,7 +83,10 @@ class BBCode
             case 'url':
                 $result = $this->convertUrl($matches);
                 break;
-            case 'img':
+            case 'iframe':
+                $result = $this->convertIframe($matches);
+                break;
+                case 'img':
                 $result = $this->convertImg($matches);
                 break;
             case 'size':
@@ -125,7 +128,20 @@ class BBCode
         $end = '</a>';
         return $start . $inner . $end;
     }
-    
+
+    /**
+     * @param array $matches
+     * @return string
+     */
+    private function convertIframe($matches)
+    {
+        $url = $matches[3];
+        if (!preg_match('/^http(s)?:/', $url)) {
+            return $matches[0];
+        }
+        return '<div class="iframe_container"><iframe src="' . $url . '" title="' . basename($url) . '"></iframe></div>';
+    }
+
     /**
      * @param array $matches
      * @return string

--- a/classes/BBCode.php
+++ b/classes/BBCode.php
@@ -43,7 +43,7 @@ class BBCode
      */
     public function __construct($emoticonDir)
     {
-        $this->pattern = '/\[(i|b|u|s|url|img|size|list|quote|code|iframe)(=.*?)?]'
+        $this->pattern = '/\[(i|b|u|s|url|img|iframe|size|list|quote|code)(=.*?)?]'
             . '(.*?)\[\/\1]/su';
         $this->context = array();
         $this->emoticonDir = rtrim($emoticonDir, '/') . '/';
@@ -70,7 +70,7 @@ class BBCode
      */
     private function doConvert($matches)
     {
-        $inlines = array('i', 'b', 'u', 's', 'url', 'iframe', 'img', 'size');
+        $inlines = array('i', 'b', 'u', 's', 'url', 'img', 'iframe', 'size');
         array_push(
             $this->context,
             in_array($matches[1], $inlines) ? 'inline' : $matches[1]
@@ -83,11 +83,11 @@ class BBCode
             case 'url':
                 $result = $this->convertUrl($matches);
                 break;
+            case 'img':
+                $result = $this->convertImg($matches);
+                break;
             case 'iframe':
                 $result = $this->convertIframe($matches);
-                break;
-                case 'img':
-                $result = $this->convertImg($matches);
                 break;
             case 'size':
                 $result = $this->convertSize($matches);
@@ -133,6 +133,19 @@ class BBCode
      * @param array $matches
      * @return string
      */
+    private function convertImg($matches)
+    {
+        $url = $matches[3];
+        if (!preg_match('/^http(s)?:/', $url)) {
+            return $matches[0];
+        }
+        return '<img src="' . $url . '" alt="' . basename($url) . '">';
+    }
+
+    /**
+     * @param array $matches
+     * @return string
+     */
     private function convertIframe($matches)
     {
         $url = $matches[3];
@@ -142,19 +155,6 @@ class BBCode
         return '<div class="iframe_container"><iframe src="' . $url . '" title="' . basename($url) . '"></iframe></div>';
     }
 
-    /**
-     * @param array $matches
-     * @return string
-     */
-    private function convertImg($matches)
-    {
-        $url = $matches[3];
-        if (!preg_match('/^http(s)?:/', $url)) {
-            return $matches[0];
-        }
-        return '<img src="' . $url . '" alt="' . basename($url) . '">';
-    }
-    
     /**
      * @param array $matches
      * @return string

--- a/classes/MainController.php
+++ b/classes/MainController.php
@@ -123,7 +123,7 @@ class MainController
         global $sn, $su;
 
         (new FaRequireCommand)->execute();
-        $bbcode = new BBCode("{$this->pluginFolder}images/");
+        $bbcode = new BBCode("{$this->pluginFolder}images/", $this->lang['title_iframe']);
         list($title, $topic) = $this->contents->getTopicWithTitle($forum, $tid);
         $editUrl = $sn . '?' . $su . '&forum_actn=edit&forum_topic=' . $tid
             . '&forum_comment=';
@@ -370,7 +370,7 @@ class MainController
 
     public function previewAction()
     {
-        $bbcode = new BBCode("{$this->pluginFolder}images/");
+        $bbcode = new BBCode("{$this->pluginFolder}images/", $this->lang['title_iframe']);
         echo $bbcode->convert($_POST['data']);
         exit;
     }

--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -120,6 +120,22 @@
 .forum_comment .forum_submit .submit {
     padding: 0.2em 1em;
 }
+.forum_comment .iframe_container {
+	position: relative;
+	overflow: hidden;
+	width: 100%;
+	padding-top: 56.25%; /* 16:9 Aspect Ratio (divide 9 by 16 = 0.5625) */
+}
+.forum_comment .iframe_container iframe {
+	border: 0px solid transparent;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	left: 0;
+	bottom: 0;
+	right: 0;
+	width: 100%;	
+}
 
 /**
  * Plugin info

--- a/forum.js
+++ b/forum.js
@@ -100,6 +100,19 @@ document.addEventListener("DOMContentLoaded", function () {
             textarea.focus();
         }
 
+        function iframe() {
+            var start = textarea.selectionStart;
+            var end = textarea.selectionEnd;
+            var url = prompt(i18n.ENTER_URL, "http://");
+            if (typeof url === "string") {
+                var repl = "[iframe]" + url + "[/iframe]";
+                var carret = start + repl.length;
+                textarea.value = textarea.value.substring(0,start) + repl + textarea.value.substring(end, textarea.textLength);
+                textarea.setSelectionRange(carret, carret);
+            }
+            textarea.focus();
+        }
+
         function url() {
             var start = textarea.selectionStart;
             var end = textarea.selectionEnd;
@@ -123,19 +136,6 @@ document.addEventListener("DOMContentLoaded", function () {
             textarea.value = textarea.value.substring(0, start) + tag +
                     textarea.value.substring(end, textarea.textLength);
             textarea.setSelectionRange(carret, carret);
-            textarea.focus();
-        }
-
-        function iframe() {
-            var start = textarea.selectionStart;
-            var end = textarea.selectionEnd;
-            var url = prompt(i18n.ENTER_URL, "http://");
-            if (typeof url === "string") {
-                var repl = "[iframe]" + url + "[/iframe]";
-                var carret = start + repl.length;
-                textarea.value = textarea.value.substring(0,start) + repl + textarea.value.substring(end, textarea.textLength);
-                textarea.setSelectionRange(carret, carret);
-            }
             textarea.focus();
         }
 
@@ -174,8 +174,8 @@ document.addEventListener("DOMContentLoaded", function () {
                 event.stopPropagation();
             },
             forum_picture_button: image,
-            forum_link_button: url,
             forum_iframe_button: iframe,
+            forum_link_button: url,
             forum_font_button: function (event) {
                 var div = form.getElementsByClassName("forum_font_sizes")[0];
                 document.addEventListener("click", function fn() {

--- a/forum.js
+++ b/forum.js
@@ -126,6 +126,19 @@ document.addEventListener("DOMContentLoaded", function () {
             textarea.focus();
         }
 
+        function iframe() {
+            var start = textarea.selectionStart;
+            var end = textarea.selectionEnd;
+            var url = prompt(i18n.ENTER_URL, "http://");
+            if (typeof url === "string") {
+                var repl = "[iframe]" + url + "[/iframe]";
+                var carret = start + repl.length;
+                textarea.value = textarea.value.substring(0,start) + repl + textarea.value.substring(end, textarea.textLength);
+                textarea.setSelectionRange(carret, carret);
+            }
+            textarea.focus();
+        }
+
         function preview() {
             var request = new XMLHttpRequest;
             request.open("POST", this.getAttribute("data-url"), true);
@@ -162,6 +175,7 @@ document.addEventListener("DOMContentLoaded", function () {
             },
             forum_picture_button: image,
             forum_link_button: url,
+            forum_iframe_button: iframe,
             forum_font_button: function (event) {
                 var div = form.getElementsByClassName("forum_font_sizes")[0];
                 document.addEventListener("click", function fn() {

--- a/help/help.htm
+++ b/help/help.htm
@@ -80,6 +80,8 @@
 <li><code>[url]https://cmsimple-xh.org/[/url]</code>: <a href="https://cmsimple-xh.org/" class="uri">https://cmsimple-xh.org/</a></li>
 <li><code>[url=https://cmsimple-xh.org/]CMSimple\_XH[/url]</code>: <a href="https://cmsimple-xh.org/">CMSimple_XH</a></li>
 <li><code>[img]https://cmsimple-xh.org/userfiles/images/flags/en.gif[/img]</code>: <img src="https://cmsimple-xh.org/userfiles/images/flags/en.gif" /></li>
+<li><code>[iframe]https://cmsimple-xh.org/userfiles/images/flags/en.gif[/iframe]</code>: <img src="https://cmsimple-xh.org/userfiles/images/flags/en.gif" /><br />
+<em>Iframes are used to embed external content, for instance, Youtube videos.</em></li>
 <li><code>[size=150]large text[/size]</code>: <span style="font-size:150%">large text</span></li>
 <li><code>[list][*]One [*]Two[/list]</code>:
 <ul>

--- a/help/help_de.htm
+++ b/help/help_de.htm
@@ -80,6 +80,8 @@
 <li><code>[url]https://cmsimple-xh.org/[/url]</code>: <a href="https://cmsimple-xh.org/" class="uri">https://cmsimple-xh.org/</a></li>
 <li><code>[url=https://cmsimple-xh.org/]CMSimple\_XH[/url]</code>: <a href="https://cmsimple-xh.org/">CMSimple_XH</a></li>
 <li><code>[img]https://cmsimple-xh.org/userfiles/images/flags/de.gif[/img]</code>: <img src="https://cmsimple-xh.org/userfiles/images/flags/de.gif" /></li>
+<li><code>[iframe]https://cmsimple-xh.org/userfiles/images/flags/de.gif[/iframe]</code>: <img src="https://cmsimple-xh.org/userfiles/images/flags/de.gif" /><br />
+<em>Iframes werden verwendet, um externe Inhalte einzubinden, z.B. Youtube-Videos.</em></li>
 <li><code>[size=150]große Schrift[/size]</code>: <span style="font-size:150%">große Schrift</span></li>
 <li><code>[list][*]Eins [*]Zwei[/list]</code>:
 <ul>

--- a/languages/de.php
+++ b/languages/de.php
@@ -35,6 +35,7 @@ $plugin_tx['forum']['lbl_tongue']="Zunge";
 $plugin_tx['forum']['lbl_surprised']="Überrascht";
 $plugin_tx['forum']['lbl_unhappy']="Unglücklich";
 $plugin_tx['forum']['lbl_picture']="Bild";
+$plugin_tx['forum']['lbl_iframe']="Iframe (z.B. für Youtube-Video)";
 $plugin_tx['forum']['lbl_link']="Link";
 $plugin_tx['forum']['lbl_size']="größe";
 $plugin_tx['forum']['lbl_big']="Groß";
@@ -48,7 +49,6 @@ $plugin_tx['forum']['lbl_code']="Code";
 $plugin_tx['forum']['lbl_clean']="Bereinigen";
 $plugin_tx['forum']['lbl_preview']="Vorschau";
 $plugin_tx['forum']['lbl_separator'] = "•";
-$plugin_tx['forum']['lbl_iframe']="iframe";
 
 $plugin_tx['forum']['mail_subject_new']="Ein neuer Kommentar wurde gepostet";
 $plugin_tx['forum']['mail_subject_edit']="Ein Kommentar wurde bearbeitet";

--- a/languages/de.php
+++ b/languages/de.php
@@ -48,6 +48,7 @@ $plugin_tx['forum']['lbl_code']="Code";
 $plugin_tx['forum']['lbl_clean']="Bereinigen";
 $plugin_tx['forum']['lbl_preview']="Vorschau";
 $plugin_tx['forum']['lbl_separator'] = "•";
+$plugin_tx['forum']['lbl_iframe']="iframe";
 
 $plugin_tx['forum']['mail_subject_new']="Ein neuer Kommentar wurde gepostet";
 $plugin_tx['forum']['mail_subject_edit']="Ein Kommentar wurde bearbeitet";

--- a/languages/de.php
+++ b/languages/de.php
@@ -50,6 +50,8 @@ $plugin_tx['forum']['lbl_clean']="Bereinigen";
 $plugin_tx['forum']['lbl_preview']="Vorschau";
 $plugin_tx['forum']['lbl_separator'] = "•";
 
+$plugin_tx['forum']['title_iframe']="Externer Inhalt";
+
 $plugin_tx['forum']['mail_subject_new']="Ein neuer Kommentar wurde gepostet";
 $plugin_tx['forum']['mail_subject_edit']="Ein Kommentar wurde bearbeitet";
 $plugin_tx['forum']['mail_attribution']="Am %2\$s schrieb %1\$s:";

--- a/languages/en.php
+++ b/languages/en.php
@@ -35,6 +35,7 @@ $plugin_tx['forum']['lbl_tongue']="Tongue";
 $plugin_tx['forum']['lbl_surprised']="Surprised";
 $plugin_tx['forum']['lbl_unhappy']="Unhappy";
 $plugin_tx['forum']['lbl_picture']="Picture";
+$plugin_tx['forum']['lbl_iframe']="Iframe (e.g. for Youtube video)";
 $plugin_tx['forum']['lbl_link']="Link";
 $plugin_tx['forum']['lbl_size']="size";
 $plugin_tx['forum']['lbl_big']="Big";
@@ -48,7 +49,6 @@ $plugin_tx['forum']['lbl_code']="Code";
 $plugin_tx['forum']['lbl_clean']="Clean";
 $plugin_tx['forum']['lbl_preview']="Preview";
 $plugin_tx['forum']['lbl_separator']="•";
-$plugin_tx['forum']['lbl_iframe']="iframe";
 
 $plugin_tx['forum']['mail_subject_new']="A new comment has been posted";
 $plugin_tx['forum']['mail_subject_edit']="A comment has been edited";

--- a/languages/en.php
+++ b/languages/en.php
@@ -50,6 +50,8 @@ $plugin_tx['forum']['lbl_clean']="Clean";
 $plugin_tx['forum']['lbl_preview']="Preview";
 $plugin_tx['forum']['lbl_separator']="•";
 
+$plugin_tx['forum']['title_iframe']="External content";
+
 $plugin_tx['forum']['mail_subject_new']="A new comment has been posted";
 $plugin_tx['forum']['mail_subject_edit']="A comment has been edited";
 $plugin_tx['forum']['mail_attribution']="On %2\$s, %1\$s wrote:";

--- a/languages/en.php
+++ b/languages/en.php
@@ -48,6 +48,7 @@ $plugin_tx['forum']['lbl_code']="Code";
 $plugin_tx['forum']['lbl_clean']="Clean";
 $plugin_tx['forum']['lbl_preview']="Preview";
 $plugin_tx['forum']['lbl_separator']="•";
+$plugin_tx['forum']['lbl_iframe']="iframe";
 
 $plugin_tx['forum']['mail_subject_new']="A new comment has been posted";
 $plugin_tx['forum']['mail_subject_edit']="A comment has been edited";

--- a/tests/unit/BBCodeTest.php
+++ b/tests/unit/BBCodeTest.php
@@ -43,7 +43,7 @@ class BBCodeTest extends TestCase
             'lbl_surprised' => 'surprised',
             'lbl_unhappy' => 'unhappy'
         );
-        $this->bbcode = new BBCode('./');
+        $this->bbcode = new BBCode('./', "External content");
     }
 
     /**

--- a/tests/unit/BBCodeTest.php
+++ b/tests/unit/BBCodeTest.php
@@ -89,6 +89,10 @@ class BBCodeTest extends TestCase
                 '<img src="https://example.com/image.jpg" alt="image.jpg">'
             ),
             array(
+                '[iframe]https://example.com/image.jpg[/iframe]',
+                '<div class="iframe_container"><iframe src="https://example.com/image.jpg" title="External content"></iframe></div>'
+            ),
+            array(
                 '[size=150]large text[/size]',
                 '<span style="font-size: 150%; line-height: 150%">'
                 . 'large text</span>'

--- a/views/form.php
+++ b/views/form.php
@@ -41,6 +41,7 @@
                 <button type="button" class="forum_list_item_button" title="<?=$this->text('lbl_list_item')?>"><i class="fa fa-asterisk"></i></button>
                 <button type="button" class="forum_quotes_button" title="<?=$this->text('lbl_quotes')?>"><i class="fa fa-quote-right"></i></button>
                 <button type="button" class="forum_code_button" title="<?=$this->text('lbl_code')?>"><i class="fa fa-code"></i></button>
+                <button type="button" class="forum_iframe_button" title="<?=$this->text('lbl_iframe')?>"><i class="fa fa-hand-rock-o"></i></button>
                 <button type="button" class="forum_preview_button" title="<?=$this->text('lbl_preview')?>" data-url="<?=$this->previewUrl()?>"><i class="fa fa-eye"></i></button>
             </div>
         </script>

--- a/views/form.php
+++ b/views/form.php
@@ -30,6 +30,7 @@
                     <button type="button" class="forum_unhappy_button" title="<?=$this->text('lbl_unhappy')?>"><img src="<?=$this->escape($this->emoticons['unhappy'])?>" alt="<?=$this->text('lbl_unhappy')?>"></button>
                 </div>
                 <button type="button" class="forum_picture_button" title="<?=$this->text('lbl_picture')?>"><i class="fa fa-picture-o"></i></button>
+                <button type="button" class="forum_iframe_button" title="<?=$this->text('lbl_iframe')?>"><i class="fa fa-hand-rock-o"></i></button>
                 <button type="button" class="forum_link_button" title="<?=$this->text('lbl_link')?>"><i class="fa fa-link"></i></button>
                 <button type="button" class="forum_font_button" title="<?=$this->text('lbl_size')?>"><i class="fa fa-font"></i></button>
                 <div class="forum_font_sizes">
@@ -41,7 +42,6 @@
                 <button type="button" class="forum_list_item_button" title="<?=$this->text('lbl_list_item')?>"><i class="fa fa-asterisk"></i></button>
                 <button type="button" class="forum_quotes_button" title="<?=$this->text('lbl_quotes')?>"><i class="fa fa-quote-right"></i></button>
                 <button type="button" class="forum_code_button" title="<?=$this->text('lbl_code')?>"><i class="fa fa-code"></i></button>
-                <button type="button" class="forum_iframe_button" title="<?=$this->text('lbl_iframe')?>"><i class="fa fa-hand-rock-o"></i></button>
                 <button type="button" class="forum_preview_button" title="<?=$this->text('lbl_preview')?>" data-url="<?=$this->previewUrl()?>"><i class="fa fa-eye"></i></button>
             </div>
         </script>


### PR DESCRIPTION
The patch has been authored by @lck-git.

TODO:
- [x] document `[iframe]`
- [x] order additions consistently
- [x] get title from lang instead of basename()
- [x] unit test
- [ ] ~~better `[iframe]` icon~~ (obsolete, see #43)
